### PR TITLE
Fix bug on expression with defined macro

### DIFF
--- a/include/base/vec.h
+++ b/include/base/vec.h
@@ -219,6 +219,7 @@ reverse__Vec(Vec *self);
 /**
  *
  * @brief Get item from Vec (no assert).
+ * @return void*?
  */
 inline void *
 safe_get__Vec(const Vec *self, Usize index)

--- a/include/core/cc/ci/token.h
+++ b/include/core/cc/ci/token.h
@@ -73,7 +73,8 @@ enum CITokenKind
     CI_TOKEN_KIND_COMMENT_DOC,
     CI_TOKEN_KIND_DOT,
     CI_TOKEN_KIND_DOT_DOT_DOT,
-    CI_TOKEN_KIND_EOF,
+    CI_TOKEN_KIND_EOF,  // End Of File
+    CI_TOKEN_KIND_EOPC, // End Of Preprocessor Condition
     CI_TOKEN_KIND_EQ,
     CI_TOKEN_KIND_EQ_EQ,
     CI_TOKEN_KIND_HASHTAG,

--- a/src/core/cc/ci/parser.c
+++ b/src/core/cc/ci/parser.c
@@ -884,7 +884,9 @@ generate_name_error__CIParser()
             }                                                                 \
     }                                                                         \
     return NEW_VARIANT(                                                       \
-      CIExpr, binary, NEW(CIExprBinary, binary_kind, lhs, rhs));
+      CIExpr,                                                                 \
+      binary,                                                                 \
+      NEW(CIExprBinary, binary_kind, ref__CIExpr(lhs), ref__CIExpr(rhs)));
 
 CIExpr *
 resolve_add_expr__CIParser(CIParser *self,
@@ -1116,7 +1118,9 @@ resolve_div_expr__CIParser(CIParser *self,
             }                                                                \
     }                                                                        \
     return NEW_VARIANT(                                                      \
-      CIExpr, binary, NEW(CIExprBinary, binary_kind, lhs, rhs));
+      CIExpr,                                                                \
+      binary,                                                                \
+      NEW(CIExprBinary, binary_kind, ref__CIExpr(lhs), ref__CIExpr(rhs)));
 
 CIExpr *
 resolve_mod_expr__CIParser(CIParser *self,
@@ -1365,7 +1369,9 @@ resolve_bit_rshift_expr__CIParser(CIParser *self,
             }                                                                \
     }                                                                        \
     return NEW_VARIANT(                                                      \
-      CIExpr, binary, NEW(CIExprBinary, binary_kind, lhs, rhs));
+      CIExpr,                                                                \
+      binary,                                                                \
+      NEW(CIExprBinary, binary_kind, ref__CIExpr(lhs), ref__CIExpr(rhs)));
 
 CIExpr *
 resolve_logical_and_expr__CIParser(CIParser *self,
@@ -1642,7 +1648,9 @@ resolve_logical_or_expr__CIParser(CIParser *self,
             }                                                                 \
     }                                                                         \
     return NEW_VARIANT(                                                       \
-      CIExpr, binary, NEW(CIExprBinary, binary_kind, lhs, rhs));
+      CIExpr,                                                                 \
+      binary,                                                                 \
+      NEW(CIExprBinary, binary_kind, ref__CIExpr(lhs), ref__CIExpr(rhs)));
 
 CIExpr *
 resolve_eq_expr__CIParser(CIParser *self,
@@ -1734,65 +1742,101 @@ resolve_expr__CIParser(CIParser *self, CIExpr *expr, bool is_partial)
               resolve_expr__CIParser(self, expr->binary.left, is_partial);
             CIExpr *rhs =
               resolve_expr__CIParser(self, expr->binary.right, is_partial);
+            CIExpr *res = NULL;
 
             switch (expr->binary.kind) {
                 case CI_EXPR_BINARY_KIND_ADD:
-                    return resolve_add_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res =
+                      resolve_add_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_SUB:
-                    return resolve_sub_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res =
+                      resolve_sub_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_MUL:
-                    return resolve_mul_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res =
+                      resolve_mul_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_DIV:
-                    return resolve_div_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res =
+                      resolve_div_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_MOD:
-                    return resolve_mod_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res =
+                      resolve_mod_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_BIT_AND:
-                    return resolve_bit_and_expr__CIParser(
+                    res = resolve_bit_and_expr__CIParser(
                       self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_BIT_OR:
-                    return resolve_bit_or_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res =
+                      resolve_bit_or_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_BIT_XOR:
-                    return resolve_bit_xor_expr__CIParser(
+                    res = resolve_bit_xor_expr__CIParser(
                       self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_BIT_LSHIFT:
-                    return resolve_bit_lshift_expr__CIParser(
+                    res = resolve_bit_lshift_expr__CIParser(
                       self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_BIT_RSHIFT:
-                    return resolve_bit_rshift_expr__CIParser(
+                    res = resolve_bit_rshift_expr__CIParser(
                       self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_AND:
-                    return resolve_logical_and_expr__CIParser(
+                    res = resolve_logical_and_expr__CIParser(
                       self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_OR:
-                    return resolve_logical_or_expr__CIParser(
+                    res = resolve_logical_or_expr__CIParser(
                       self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_EQ:
-                    return resolve_eq_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res = resolve_eq_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_NE:
-                    return resolve_ne_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res = resolve_ne_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_LESS:
-                    return resolve_lt_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res = resolve_lt_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_LESS_EQ:
-                    return resolve_le_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res = resolve_le_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_GREATER:
-                    return resolve_gt_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res = resolve_gt_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 case CI_EXPR_BINARY_KIND_GREATER_EQ:
-                    return resolve_ge_expr__CIParser(
-                      self, lhs, rhs, is_partial);
+                    res = resolve_ge_expr__CIParser(self, lhs, rhs, is_partial);
+
+                    break;
                 default:
                     UNREACHABLE("unknown binary kind");
             }
+
+            FREE(CIExpr, lhs);
+            FREE(CIExpr, rhs);
+
+            return res;
         }
         case CI_EXPR_KIND_GROUPING:
             return NEW_VARIANT(
@@ -1873,7 +1917,6 @@ check_if_resolved_expr_is_true__CIParser(CIParser *self, CIExpr *expr)
     if (!has_reach_end__CITokensIters(&self->tokens_iters)) { \
         FAILED("expected only one expression");               \
     } else {                                                  \
-        pop_iter__CITokensIters(&self->tokens_iters);         \
         init_next_token__CIParser(self, false);               \
     }
 
@@ -1885,7 +1928,7 @@ check_if_resolved_expr_is_true__CIParser(CIParser *self, CIExpr *expr)
         add_iter__CITokensIters(                                             \
           &self->tokens_iters,                                               \
           NEW(CITokensIter, preprocessor->preprocessor_##k.cond));           \
-        init_next_token__CIParser(self, false);                              \
+        init_next_token__CIParser(self, true);                               \
                                                                              \
         PREPROCESSOR_PARSE_EXPR(cond);                                       \
                                                                              \
@@ -2032,14 +2075,16 @@ next_token__CIParser(CIParser *self)
         if (top->iter.count == 0) {
             init_next_token__CIParser(self, true);
         } else {
-            self->tokens_iters.previous_token =
-              self->tokens_iters.current_token;
-            self->tokens_iters.current_token = next__VecIter(&top->iter);
+            CIToken *next_token = next__VecIter(&top->iter);
 
-            // If the `current_token` is `NULL`, that means we have reached the
+            // If the `next_token` is `NULL`, that means we have reached the
             // end of the current iter (top). So we pop the current iter from
             // the stack and call `next_token__CITokensIters` again.
-            if (!self->tokens_iters.current_token) {
+            if (next_token) {
+                self->tokens_iters.previous_token =
+                  self->tokens_iters.current_token;
+                self->tokens_iters.current_token = next_token;
+            } else {
                 pop_iter__CITokensIters(&self->tokens_iters);
 
                 continue;

--- a/src/core/cc/ci/token.c
+++ b/src/core/cc/ci/token.c
@@ -2311,7 +2311,8 @@ has_reach_end__CITokensIters(CITokensIters *self)
 {
     CITokensIter *iter = peek__Stack(self->iters);
 
-    return iter->iter.count >= iter->iter.vec->len - 1;
+    return iter->iter.count >= iter->iter.vec->len - 1 ||
+           self->current_token->kind == CI_TOKEN_KIND_EOF;
 }
 
 DESTRUCTOR(CITokensIters, const CITokensIters *self)

--- a/src/core/cc/ci/token.c
+++ b/src/core/cc/ci/token.c
@@ -1062,6 +1062,8 @@ to_string__CIToken(CIToken *self)
             return from__String("...");
         case CI_TOKEN_KIND_EOF:
             return from__String("EOF");
+        case CI_TOKEN_KIND_EOPC:
+            return from__String("EOPC");
         case CI_TOKEN_KIND_EQ:
             return from__String("=");
         case CI_TOKEN_KIND_EQ_EQ:
@@ -1472,6 +1474,8 @@ IMPL_FOR_DEBUG(to_string, CITokenKind, enum CITokenKind self)
             return "CI_TOKEN_KIND_DOT_DOT_DOT";
         case CI_TOKEN_KIND_EOF:
             return "CI_TOKEN_KIND_EOF";
+        case CI_TOKEN_KIND_EOPC:
+            return "CI_TOKEN_KIND_EOPC";
         case CI_TOKEN_KIND_EQ:
             return "CI_TOKEN_KIND_EQ";
         case CI_TOKEN_KIND_EQ_EQ:
@@ -2311,8 +2315,10 @@ has_reach_end__CITokensIters(CITokensIters *self)
 {
     CITokensIter *iter = peek__Stack(self->iters);
 
-    return iter->iter.count >= iter->iter.vec->len - 1 ||
-           self->current_token->kind == CI_TOKEN_KIND_EOF;
+    return (iter->iter.count >= iter->iter.vec->len - 1 ||
+            (self->current_token &&
+             self->current_token->kind == CI_TOKEN_KIND_EOF)) &&
+           self->iters->len == 1;
 }
 
 DESTRUCTOR(CITokensIters, const CITokensIters *self)


### PR DESCRIPTION
Now an expression like this should work:

```c
 #if defined(ABC) && defined(DEF)
 // ...
 #endif
```