### PR TITLE
Fix leak during macro param injection

### DIFF
--- a/src/core/cc/ci/parser.c
+++ b/src/core/cc/ci/parser.c
@@ -3207,7 +3207,7 @@ loop:
                     case CI_TOKEN_EOT_CONTEXT_MACRO_PARAM:
                         // NOTE: Restore the saved token in EOT.
                         if (next_token->eot.macro_param) {
-                            next_token = next_token->eot.macro_param->next;
+                            next_token = next_token->eot.macro_param;
                             next_token->eot.macro_param = NULL;
                         }
 


### PR DESCRIPTION
Code in question:

```c
#define USE_A 1

#define DEF(x) USE_##x

#if DEF(A)
int add(int x, int y) {
	return x + y;
}
#endif

int main() {
	int b = DEF(A);
}
```