### PR TITLE
Get compiler include dirs

### DIFF
--- a/include/core/cc/ci/include.h
+++ b/include/core/cc/ci/include.h
@@ -28,19 +28,21 @@
 #include <base/platform.h>
 #include <base/vec.h>
 
+#include <core/cc/ci/config.h>
+
 /**
  *
  * @brief Initialize include directories vector.
  */
 void
-init_include_dirs__CIInclude();
+init_include_dirs__CIInclude(const String *compiler_path);
 
 /**
  *
  * @brief Add include directory to `include_dirs` vector.
  */
 void
-add_include_dir__CIInclude(char *include_dir);
+add_include_dir__CIInclude(String *include_dir);
 
 /**
  *

--- a/src/core/cc/ci/config.c
+++ b/src/core/cc/ci/config.c
@@ -45,7 +45,8 @@ parse_compiler__CIConfig(YAMLLoadRes *yaml_load_res,
                          const char *absolute_config_dir);
 
 static void
-parse_include_dirs__CIConfig(YAMLLoadRes *yaml_load_res);
+parse_include_dirs__CIConfig(const String *compiler_path,
+                             YAMLLoadRes *yaml_load_res);
 
 /// @return Vec<CILibrary*>*
 static Vec *
@@ -174,7 +175,8 @@ parse_compiler__CIConfig(YAMLLoadRes *yaml_load_res,
 }
 
 void
-parse_include_dirs__CIConfig(YAMLLoadRes *yaml_load_res)
+parse_include_dirs__CIConfig(const String *compiler_path,
+                             YAMLLoadRes *yaml_load_res)
 {
     // include_dirs:
     //   - dir
@@ -182,7 +184,7 @@ parse_include_dirs__CIConfig(YAMLLoadRes *yaml_load_res)
     //   ...
 
     // Initialize include directories workspace
-    init_include_dirs__CIInclude();
+    init_include_dirs__CIInclude(compiler_path);
 
     Int32 include_dirs_value_id = GET_KEY_ON_DEFAULT_MAPPING__YAML(
       yaml_load_res, FIRST_DOCUMENT, "include_dirs");
@@ -200,7 +202,10 @@ parse_include_dirs__CIConfig(YAMLLoadRes *yaml_load_res)
                   FIRST_DOCUMENT,
                   include_dirs_value_node,
                   include_dir,
-                  { add_include_dir__CIInclude(include_dir_value); });
+                  {
+                      add_include_dir__CIInclude(
+                        from__String(include_dir_value));
+                  });
 
                 break;
             default:
@@ -464,7 +469,7 @@ parse__CIConfig(const char *config_dir)
     CICompiler compiler =
       parse_compiler__CIConfig(&yaml_load_res, absolute_config_dir);
 
-    parse_include_dirs__CIConfig(&yaml_load_res);
+    parse_include_dirs__CIConfig(compiler.path, &yaml_load_res);
 
     Vec *libraries =
       parse_libraries__CIConfig(&yaml_load_res, absolute_config_dir);

--- a/src/core/cc/ci/parser.c
+++ b/src/core/cc/ci/parser.c
@@ -6177,10 +6177,10 @@ resolve_preprocessor_include__CIParser(CIParser *self,
     const Vec *include_dirs = get_include_dirs__CIInclude();
 
     for (Usize i = 0; i < include_dirs->len; ++i) {
-        const char *include_dir = get__Vec(include_dirs, i);
+        const String *include_dir = get__Vec(include_dirs, i);
         // include_dir + '/' + preprocessor_include.value
         char *full_include_path =
-          format("{s}/{S}",
+          format("{S}/{S}",
                  include_dir,
                  preprocessor_include_token->preprocessor_include.value);
 


### PR DESCRIPTION
- Get include dirs of GCC/Clang.

NOTE: For the moment, only Clang and GCC are supported.
