### PR TITLE
Parse `nullptr` expression

### DIFF
--- a/include/core/cc/ci/ast.h
+++ b/include/core/cc/ci/ast.h
@@ -2367,6 +2367,7 @@ enum CIExprKind
     CI_EXPR_KIND_GROUPING,
     CI_EXPR_KIND_IDENTIFIER,
     CI_EXPR_KIND_LITERAL,
+    CI_EXPR_KIND_NULLPTR,
     CI_EXPR_KIND_SIZEOF,
     CI_EXPR_KIND_STRUCT_CALL,
     CI_EXPR_KIND_TERNARY,
@@ -2405,6 +2406,12 @@ struct CIExpr
         CIExprUnary unary;
     };
 };
+
+/**
+ *
+ * @brief Construct CIExpr type.
+ */
+CONSTRUCTOR(CIExpr *, CIExpr, enum CIExprKind kind);
 
 /**
  *

--- a/src/core/cc/ci/generator.c
+++ b/src/core/cc/ci/generator.c
@@ -961,6 +961,10 @@ generate_function_expr__CIGenerator(const CIExpr *expr)
             generate_function_literal_expr__CIGenerator(&expr->literal);
 
             break;
+        case CI_EXPR_KIND_NULLPTR:
+            write_str__CIGenerator("nullptr");
+
+            break;
         case CI_EXPR_KIND_SIZEOF:
             write_str__CIGenerator("sizeof(");
             generate_function_expr__CIGenerator(expr->sizeof_);

--- a/src/core/cc/ci/parser.c
+++ b/src/core/cc/ci/parser.c
@@ -2620,6 +2620,8 @@ resolve_expr__CIParser(CIParser *self, CIExpr *expr, bool is_partial)
             TODO("resolve identifier");
         case CI_EXPR_KIND_LITERAL:
             return ref__CIExpr(expr);
+        case CI_EXPR_KIND_NULLPTR:
+            return ref__CIExpr(expr);
         case CI_EXPR_KIND_SIZEOF:
             TODO("resolve sizeof");
         case CI_EXPR_KIND_STRUCT_CALL:
@@ -4983,6 +4985,8 @@ parse_primary_expr__CIParser(CIParser *self)
 
             break;
         }
+        case CI_TOKEN_KIND_KEYWORD_NULLPTR:
+            return NEW(CIExpr, CI_EXPR_KIND_NULLPTR);
         case CI_TOKEN_KIND_BUILTIN_MACRO___HAS_FEATURE: {
             bool has_feature = false;
 


### PR DESCRIPTION
## Resouces

- [nullptr](https://en.cppreference.com/w/c/language/nullptr)
- [nullptr_t](https://en.cppreference.com/w/c/types/nullptr_t)
