### PR TITLE
Move the token standard check to the parser 

### DIFF
--- a/include/core/cc/ci/scanner.h
+++ b/include/core/cc/ci/scanner.h
@@ -79,6 +79,24 @@ run__CIScanner(CIScanner *self, bool dump_scanner);
 
 /**
  *
+ * @brief Get `tokens_feature` reference.
+ * @return const CIFeature* (&)
+ */
+const CIFeature *
+get_tokens_feature__CIScanner();
+
+#define CHECK_STANDARD_SINCE(standard, since, block) \
+    if (standard < since) {                          \
+        block;                                       \
+    }
+
+#define CHECK_STANDARD_UNTIL(standard, until, block) \
+    if (standard >= until) {                         \
+        block;                                       \
+    }
+
+/**
+ *
  * @brief Free CIScanner type.
  */
 inline DESTRUCTOR(CIScanner, const CIScanner *self)


### PR DESCRIPTION
This avoids evaluating the tokens contained in conditional
preprocessors (#if, ...) if their condition is potentially false, and
therefore avoids generating bad diagnostic messages.