### PR TITLE
Fix bug in include system

### DIFF
--- a/include/core/cc/ci/token.h
+++ b/include/core/cc/ci/token.h
@@ -350,6 +350,11 @@ typedef struct CITokenEot
     enum CITokenEotContext ctx;
     union
     {
+        // Save the token before connecting it to the included tokens.
+        //
+        // include -> <tokens_of_the_include> -> ...
+        // ^^^^^^^
+        struct CIToken *include; // struct CIToken* (&)
         // Result of: `id`##`id2`
         struct CIToken *merged_token; // struct CIToken*
         // This represents the token to restore after reaching the EOT token in


### PR DESCRIPTION
Poor state restoration, causing infinite loops and bad memory releases.


Here's a valgrind report, which is obtainable for this bug: [valgrind_out.txt](https://github.com/user-attachments/files/15749721/valgrind_out.txt)
