### PR TITLE
Fix: Allow prototype duplications

### DIFF
--- a/include/core/cc/ci/ast.h
+++ b/include/core/cc/ci/ast.h
@@ -1071,6 +1071,13 @@ inline CONSTRUCTOR(CIDeclEnum, CIDeclEnum, String *name, Vec *variants)
 
 /**
  *
+ * @brief Verify if the both enums prototypes are equal.
+ */
+bool
+match_prototype__CIDeclEnum(const CIDeclEnum *self, const CIDeclEnum *other);
+
+/**
+ *
  * @brief Convert CIDeclEnum in String.
  * @note This function is only used to debug.
  */
@@ -1078,6 +1085,15 @@ inline CONSTRUCTOR(CIDeclEnum, CIDeclEnum, String *name, Vec *variants)
 String *
 IMPL_FOR_DEBUG(to_string, CIDeclEnum, const CIDeclEnum *self);
 #endif
+
+/**
+ *
+ * @brief Free CIDeclEnum type in prototype case.
+ */
+inline void
+free_as_prototype__CIDeclEnum(const CIDeclEnum *self)
+{ /* No-free */
+}
 
 /**
  *
@@ -1156,6 +1172,25 @@ serialize_name__CIDeclFunction(const CIDeclFunction *self,
 
 /**
  *
+ * @brief Check if the both generic params are equal.
+ */
+inline bool
+eq_generic_params__CIDeclFunction(const CIDeclFunction *self,
+                                  const CIDeclFunction *other)
+{
+    return eq_op__CIGenericParams(self->generic_params, other->generic_params);
+}
+
+/**
+ *
+ * @brief Verify if the both functions prototypes are equal.
+ */
+bool
+match_prototype__CIDeclFunction(const CIDeclFunction *self,
+                                const CIDeclFunction *other);
+
+/**
+ *
  * @brief Convert CIDeclFunction in String.
  * @note This function is only used to debug.
  */
@@ -1163,6 +1198,13 @@ serialize_name__CIDeclFunction(const CIDeclFunction *self,
 String *
 IMPL_FOR_DEBUG(to_string, CIDeclFunction, const CIDeclFunction *self);
 #endif
+
+/**
+ *
+ * @brief Free CIDeclFunction type in prototype case.
+ */
+void
+free_as_prototype__CIDeclFunction(const CIDeclFunction *self);
 
 /**
  *
@@ -1407,6 +1449,25 @@ inline CONSTRUCTOR(CIDeclTypedef,
 
 /**
  *
+ * @brief Check if the both generic params are equal.
+ */
+inline bool
+eq_generic_params__CIDeclTypedef(const CIDeclTypedef *self,
+                                 const CIDeclTypedef *other)
+{
+    return eq_op__CIGenericParams(self->generic_params, other->generic_params);
+}
+
+/**
+ *
+ * @brief Verify if the both typedefs prototypes are equal.
+ */
+bool
+match_prototype__CIDeclTypedef(const CIDeclTypedef *self,
+                               const CIDeclTypedef *other);
+
+/**
+ *
  * @brief Serialize typedef name.
  */
 String *
@@ -1425,9 +1486,19 @@ IMPL_FOR_DEBUG(to_string, CIDeclTypedef, const CIDeclTypedef *self);
 
 /**
  *
+ * @brief Free CIDeclTypedef type in prototype case.
+ */
+void
+free_as_prototype__CIDeclTypedef(const CIDeclTypedef *self);
+
+/**
+ *
  * @brief Free CIDeclTypedef type.
  */
-DESTRUCTOR(CIDeclTypedef, const CIDeclTypedef *self);
+inline DESTRUCTOR(CIDeclTypedef, const CIDeclTypedef *self)
+{
+    free_as_prototype__CIDeclTypedef(self);
+}
 
 typedef struct CIDeclTypedefGen
 {

--- a/include/core/cc/ci/result.h
+++ b/include/core/cc/ci/result.h
@@ -322,9 +322,12 @@ add_include__CIResultFile(const CIResultFile *self);
 
 /**
  *
- * @brief Add enum declaration to enums field. If the enum name is already
- * defined, the declaration pointer is returned, otherwise NULL is returned.
- * @return const CIDecl*?
+ * @brief Add enum declaration to enums field. If the enumeration name is
+ * already declared, the enumeration found will be returned, but if it's a valid
+ * redeclaration, for example in the case of prototypes, the `CIDecl` pointer
+ * passed in this function will be returned. Finally, if the addition is
+ * successful, a NULL pointer is returned.
+ * @return const CIDecl*? (&)
  */
 const CIDecl *
 add_enum__CIResultFile(const CIResultFile *self, CIDecl *enum_);
@@ -332,18 +335,23 @@ add_enum__CIResultFile(const CIResultFile *self, CIDecl *enum_);
 /**
  *
  * @brief Add function declaration to functions field. If the function name is
- * already defined, the declaration pointer is returned, otherwise NULL is
- * returned.
- * @return const CIDecl*?
+ * already declared, the function found will be returned, but if it's a valid
+ * redeclaration, for example in the case of prototypes, the `CIDecl` pointer
+ * passed in this function will be returned. Finally, if the addition is
+ * successful, a NULL pointer is returned.
+ * @return const CIDecl*? (&)
  */
 const CIDecl *
 add_function__CIResultFile(const CIResultFile *self, CIDecl *function);
 
 /**
  *
- * @brief Add struct declaration to structs field. If the struct name is already
- * defined, the declaration pointer is returned, otherwise NULL is returned.
- * @return const CIDecl*?
+ * @brief Add struct declaration to structs field. If the struct name is
+ * already declared, the struct found will be returned, but if it's a valid
+ * redeclaration, for example in the case of prototypes, the `CIDecl` pointer
+ * passed in this function will be returned. Finally, if the addition is
+ * successful, a NULL pointer is returned.
+ * @return const CIDecl*? (&)
  */
 const CIDecl *
 add_struct__CIResultFile(const CIResultFile *self, CIDecl *struct_);
@@ -351,18 +359,23 @@ add_struct__CIResultFile(const CIResultFile *self, CIDecl *struct_);
 /**
  *
  * @brief Add typedef declaration to typedefs field. If the typedef name is
- * already defined, the declaration pointer is returned, otherwise NULL is
- * returned.
- * @return const CIDecl*?
+ * already declared, the typedef found will be returned, but if it's a valid
+ * redeclaration, for example in the case of prototypes, the `CIDecl` pointer
+ * passed in this function will be returned. Finally, if the addition is
+ * successful, a NULL pointer is returned.
+ * @return const CIDecl*? (&)
  */
 const CIDecl *
 add_typedef__CIResultFile(const CIResultFile *self, CIDecl *typedef_);
 
 /**
  *
- * @brief Add union declaration to unions field. If the union name is already
- * defined, the declaration pointer is returned, otherwise NULL is returned.
- * @return const CIDecl*?
+ * @brief Add union declaration to unions field. If the union name is
+ * already declared, the union found will be returned, but if it's a valid
+ * redeclaration, for example in the case of prototypes, the `CIDecl` pointer
+ * passed in this function will be returned. Finally, if the addition is
+ * successful, a NULL pointer is returned.
+ * @return const CIDecl*? (&)
  */
 const CIDecl *
 add_union__CIResultFile(const CIResultFile *self, CIDecl *union_);
@@ -370,9 +383,11 @@ add_union__CIResultFile(const CIResultFile *self, CIDecl *union_);
 /**
  *
  * @brief Add variable declaration to variables field. If the variable name is
- * already defined, the declaration pointer is returned, otherwise NULL is
- * returned.
- * @return const CIDecl*?
+ * already declared, the variable found will be returned, but if it's a valid
+ * redeclaration, for example in the case of prototypes, the `CIDecl` pointer
+ * passed in this function will be returned. Finally, if the addition is
+ * successful, a NULL pointer is returned.
+ * @return const CIDecl*? (&)
  */
 const CIDecl *
 add_variable__CIResultFile(const CIResultFile *self,

--- a/src/ex/lib/lily_core_cc_ci.c
+++ b/src/ex/lib/lily_core_cc_ci.c
@@ -148,6 +148,9 @@ extern inline DESTRUCTOR(CIDeclEnumVariant, CIDeclEnumVariant *self);
 
 extern inline CONSTRUCTOR(CIDeclEnum, CIDeclEnum, String *name, Vec *variants);
 
+extern inline void
+free_as_prototype__CIDeclEnum(const CIDeclEnum *self);
+
 extern inline CONSTRUCTOR(CIDeclFunction,
                           CIDeclFunction,
                           String *name,
@@ -155,6 +158,10 @@ extern inline CONSTRUCTOR(CIDeclFunction,
                           CIGenericParams *generic_params,
                           Vec *params,
                           Vec *body);
+
+extern inline bool
+eq_generic_params__CIDeclFunction(const CIDeclFunction *self,
+                                  const CIDeclFunction *other);
 
 extern inline CONSTRUCTOR(CIDeclFunctionGen,
                           CIDeclFunctionGen,
@@ -185,6 +192,12 @@ extern inline CONSTRUCTOR(CIDeclTypedef,
                           String *name,
                           CIGenericParams *generic_params,
                           CIDataType *data_type);
+
+extern inline DESTRUCTOR(CIDeclTypedef, const CIDeclTypedef *self);
+
+extern inline bool
+eq_generic_params__CIDeclTypedef(const CIDeclTypedef *self,
+                                 const CIDeclTypedef *other);
 
 extern inline CONSTRUCTOR(CIDeclTypedefGen,
                           CIDeclTypedefGen,


### PR DESCRIPTION
Allow that:

e.g.

```c
struct A;
struct A;
```