### PR TITLE
Fix dependencies order generation

### DIFF
--- a/include/core/cc/ci/result.h
+++ b/include/core/cc/ci/result.h
@@ -140,6 +140,7 @@ typedef struct CIResultEntity
     Vec *typedefs;           // Vec<CIDecl*>*
     Vec *unions;             // Vec<CIDecl*>*
     Vec *variables;          // Vec<CIDecl*>*
+    Vec *decls;              // Vec<CIDecl*>*
     String *filename_result; // String*?
     enum CIResultEntityKind kind;
 } CIResultEntity;
@@ -163,6 +164,7 @@ inline CONSTRUCTOR(CIResultEntity,
                              .typedefs = NEW(Vec),
                              .unions = NEW(Vec),
                              .variables = NEW(Vec),
+                             .decls = NEW(Vec),
                              .filename_result = filename_result,
                              .kind = kind };
 }

--- a/src/core/cc/ci/result.c
+++ b/src/core/cc/ci/result.c
@@ -84,6 +84,8 @@ void
 reset__CIResultEntity(CIResultEntity *self)
 {
 #define FREE_ENTITY_VECS()                                                    \
+    FREE_BUFFER_ITEMS(self->decls->buffer, self->decls->len, CIDecl);         \
+    FREE(Vec, self->decls);                                                   \
     FREE_BUFFER_ITEMS(self->enums->buffer, self->enums->len, CIDecl);         \
     FREE(Vec, self->enums);                                                   \
     FREE_BUFFER_ITEMS(self->functions->buffer, self->functions->len, CIDecl); \
@@ -99,6 +101,7 @@ reset__CIResultEntity(CIResultEntity *self)
 
     FREE_ENTITY_VECS();
 
+    self->decls = NEW(Vec);
     self->enums = NEW(Vec);
     self->functions = NEW(Vec);
     self->structs = NEW(Vec);
@@ -378,6 +381,7 @@ update_prototype__CIResult(CIDecl *prototype, CIDecl *decl)
     }                                                                      \
                                                                            \
     push__Vec(v, X);                                                       \
+    push__Vec(self->file_analysis->entity->decls, ref__CIDecl(X));         \
                                                                            \
     return self->owner &&                                                  \
                (X->kind != CI_DECL_KIND_VARIABLE || !X->variable.is_local) \


### PR DESCRIPTION
In some cases, types were generated after their first use, causing
compile-time errors.

example of input causing invalid generation:

```ci
typedef int X;

enum Letter : X {
  A,
  B,
  C
};
```