### PR TITLE
Fix array LLVM generation

### DIFF
--- a/src/core/lily/analysis/checked/data_type.c
+++ b/src/core/lily/analysis/checked/data_type.c
@@ -2995,7 +2995,7 @@ IMPL_FOR_DEBUG(to_string, LilyCheckedDataType, const LilyCheckedDataType *self)
     switch (self->kind) {
         case LILY_CHECKED_DATA_TYPE_KIND_ARRAY: {
             char *s =
-              format(", array = {Sr} }",
+              format(", array = {sa} }",
                      to_string__Debug__LilyCheckedDataTypeArray(&self->array));
 
             PUSH_STR_AND_FREE(res, s);

--- a/src/core/lily/mir/dt.c
+++ b/src/core/lily/mir/dt.c
@@ -332,8 +332,14 @@ IMPL_FOR_DEBUG(to_string, LilyMirDt, const LilyMirDt *self)
         case LILY_MIR_DT_KIND_ANY:
             return format__String("\x1b[35many\x1b[0m");
         case LILY_MIR_DT_KIND_ARRAY:
-            return format__String("\x1b[35m[{d} x {Sr}]\x1b[0m",
-                                  self->array.len,
+            if (self->array.len.is_undef) {
+                return format__String(
+                  "\x1b[35m[? x {Sr}]\x1b[0m",
+                  to_string__Debug__LilyMirDt(self->array.dt));
+            }
+
+            return format__String("\x1b[35m[{zu} x {Sr}]\x1b[0m",
+                                  self->array.len.len,
                                   to_string__Debug__LilyMirDt(self->array.dt));
         case LILY_MIR_DT_KIND_BYTES:
             return format__String("\x1b[35mBytes\x1b[0m");


### PR DESCRIPTION
Issue:

```
$ ./bin/Debug/lilyc ./tests/samples/array/sized_array.lily
error: Invalid indices for GEP pointer type!
  %local.array.item = getelementptr i32, ptr %local.array, i8 0, i8 0, i64 0
Store operand must be a pointer.
  store ptr %local.array.item, i32 1, align 8
Invalid indices for GEP pointer type!
  %local.array.item1 = getelementptr i32, ptr %local.array, i8 0, i8 0, i64 1
Store operand must be a pointer.
  store ptr %local.array.item1, i32 2, align 8
Invalid indices for GEP pointer type!
  %local.array.item2 = getelementptr i32, ptr %local.array, i8 0, i8 0, i64 2
Store operand must be a pointer.
  store ptr %local.array.item2, i32 3, align 8
Invalid indices for GEP pointer type!
  %local.array.item3 = getelementptr i32, ptr %local.array, i8 0, i8 0, i64 3
Store operand must be a pointer.
  store ptr %local.array.item3, i32 4, align 8
Invalid indices for GEP pointer type!
  %local.array.item4 = getelementptr i32, ptr %local.array, i8 0, i8 0, i64 4
Store operand must be a pointer.
  store ptr %local.array.item4, i32 5, align 8
```