### PR TITLE
Associate macro param with the right macro call ID

### DIFF
--- a/include/core/cc/ci/parser.h
+++ b/include/core/cc/ci/parser.h
@@ -180,7 +180,7 @@ typedef struct CIParser
     const CITokens *tokens;   // const CITokens* (&)
     CIToken *current_token;   // CIToken* (&)
     CIToken *previous_token;  // CIToken* (&)
-    Stack *macros_call;       // Stack<CIParserMacroCall*>*
+    Vec *macros_call;         // Vec<CIParserMacroCall*>*
     CIParserVisitWaitingList visit_waiting_list;
 } CIParser;
 

--- a/src/core/cc/ci/scanner.c
+++ b/src/core/cc/ci/scanner.c
@@ -1731,8 +1731,10 @@ scan_multi_part_keyword__CIScanner(CIScanner *self, CIScannerContext *ctx)
 
                         if (!strcmp(param->name->buffer,
                                     last_token->identifier->buffer)) {
-                            res = NEW_VARIANT(
-                              CIToken, macro_param, last_token->location, i);
+                            res = NEW_VARIANT(CIToken,
+                                              macro_param,
+                                              last_token->location,
+                                              NEW(CITokenMacroParam, i));
 
                             FREE(CIToken, last_token);
                             last_token = NULL;

--- a/src/ex/lib/lily_core_cc_ci.c
+++ b/src/ex/lib/lily_core_cc_ci.c
@@ -515,6 +515,8 @@ extern inline CONSTRUCTOR(CITokenEot, CITokenEot, enum CITokenEotContext ctx);
 
 extern inline VARIANT_CONSTRUCTOR(CITokenEot, CITokenEot, macro_call);
 
+extern inline VARIANT_CONSTRUCTOR(CITokenEot, CITokenEot, macro_param);
+
 extern inline CONSTRUCTOR(CITokenLiteralConstantInt,
                           CITokenLiteralConstantInt,
                           enum CITokenLiteralConstantIntSuffix suffix,
@@ -591,5 +593,11 @@ extern inline CONSTRUCTOR(CITokenPreprocessorInclude,
 
 extern inline DESTRUCTOR(CITokenPreprocessorInclude,
                          const CITokenPreprocessorInclude *self);
+
+extern inline DESTRUCTOR(CITokenMacroCallId, CITokenMacroCallId *self);
+
+extern inline CONSTRUCTOR(CITokenMacroParam, CITokenMacroParam, Usize id);
+
+extern inline DESTRUCTOR(CITokenMacroParam, const CITokenMacroParam *self);
 
 #endif // LILY_EX_LIB_LILY_CORE_CC_CI_C


### PR DESCRIPTION
Before this change, this code did not work:

```c
#define X(x) x
#define X2(x) X(x)

int main() {
	int b = X2(2);
}
```