### PR TITLE
Fix generic params

### DIFF
--- a/src/core/cc/ci/README.md
+++ b/src/core/cc/ci/README.md
@@ -41,13 +41,13 @@ In my case, the CI advantage is that I can translate Lily's source code in a ver
 For the time being, the only real feature is generic support:
 
 ```c
-struct Vec[@T] {
+struct Vec.[@T] {
     @T *buffer;
     unsigned int len;
     unsigned int capacity;
 };
 
-struct Vec.[@T] init__Vec[@T]() {
+struct Vec.[@T] init__Vec.[@T]() {
     return (struct Vec.[@T]){ .buffer = NULL, .len = 0, .capacity = 4 };
 }
 


### PR DESCRIPTION
Implements the following syntax for all types of generic params (declaration or call):

```c
struct Vec.[@T] {
  @T *buffer;
}

@T f.[@T](@T x) {
  return x;
}
```
