### PR TITLE
Fix stack overflow while typechecking named struct

### DIFF
--- a/src/core/cc/ci/parser.c
+++ b/src/core/cc/ci/parser.c
@@ -8566,6 +8566,11 @@ is_valid_implicit_cast__CIParser(const CIParser *self,
               self, left, right->post_const, typecheck_ctx);
         case CI_DATA_TYPE_KIND_STRUCT:
             if (left->kind == CI_DATA_TYPE_KIND_STRUCT) {
+                if (left->struct_.name && right->struct_.name) {
+                    return !strcmp(left->struct_.name->buffer,
+                                   right->struct_.name->buffer);
+                }
+
                 // NOTE: We perform a check if one or both fields are NULL, as
                 // the `eq__CIDataType` function returns a false, because at the
                 // point of this function, we can't perform a thorough check


### PR DESCRIPTION
The following code now works:

```ci
struct Node.[@T] {
	@T value;
	struct Node.[@T] *next;
};

struct Node.[@T]
new__Node.[@T](@T value)
{
	return (struct Node.[@T]){ .value = value, .next = NULL };
}

int main() {
        struct Node.[int] second = new__Node.[int](2);
        struct Node.[float] three = new__Node.[float](2.2);
}
```