### PR TITLE
Add the ability to call function as identifier

### DIFF
--- a/include/core/cc/ci/ast.h
+++ b/include/core/cc/ci/ast.h
@@ -1119,6 +1119,15 @@ serialize_name__CIDataType(const CIDataType *self,
 
 /**
  *
+ * @brief Wrap a pointer to data type.
+ * @param self CIDataType*
+ * @return CIDataType*
+ */
+CIDataType *
+wrap_ptr__CIDataType(CIDataType *self, int ptr_ctx);
+
+/**
+ *
  * @brief Convert CIDataType in String.
  * @note This function is only used to debug.
  */

--- a/include/core/cc/ci/result.h
+++ b/include/core/cc/ci/result.h
@@ -538,6 +538,15 @@ search_data_type__CIResultFile(const CIResultFile *self, const String *name);
 
 /**
  *
+ * @brief Search identifier declaration in decls map.
+ */
+CIDecl *
+search_identifier__CIResultFile(const CIResultFile *self,
+                                const CIScope *scope,
+                                const String *name);
+
+/**
+ *
  * @brief Run the scanner, parser and the C generator.
  */
 void

--- a/src/core/cc/ci/generator.c
+++ b/src/core/cc/ci/generator.c
@@ -588,6 +588,8 @@ generate_data_type__CIGenerator(CIDataType *data_type)
             if (subs_data_type->function.params) {
                 generate_function_params__CIGenerator(
                   subs_data_type->function.params);
+            } else {
+                write_str__CIGenerator("()");
             }
 
             break;

--- a/src/core/cc/ci/result.c
+++ b/src/core/cc/ci/result.c
@@ -711,6 +711,25 @@ search_data_type__CIResultFile(const CIResultFile *self, const String *name)
     return NULL;
 }
 
+CIDecl *
+search_identifier__CIResultFile(const CIResultFile *self,
+                                const CIScope *scope,
+                                const String *name)
+{
+    CIDecl *variable = search_variable__CIResultFile(self, scope, name);
+    CIDecl *function = search_function__CIResultFile(self, name);
+
+    if (variable) {
+        if (variable->variable.is_local) {
+            return variable;
+        }
+    } else if (function) {
+        return function;
+    }
+
+    return NULL;
+}
+
 void
 run__CIResultFile(CIResultFile *self)
 {


### PR DESCRIPTION
The following code now works:

```ci
int f2() {
	return 3;
}

int main() {
	int (*f2_p)() = &f2;
}
```