### PR TITLE
Fix: Generate storage class for variable declaration

### DIFF
--- a/src/core/cc/ci/generator.c
+++ b/src/core/cc/ci/generator.c
@@ -1656,6 +1656,8 @@ generate_decl__CIGenerator(const CIDecl *decl)
 
                 break;
             case CI_DECL_KIND_VARIABLE:
+				generate_storage_class__CIGenerator(&decl->storage_class_flag);
+
                 return generate_variable_decl__CIGenerator(&decl->variable);
             default:
                 UNREACHABLE("unknown variant");


### PR DESCRIPTION
The following code ends with a segfault because the variable `stderr` do not use the `extern` storage class.

Minimal version:

```c
[[noreturn]] extern void __assert_fail(const char* __assertion, const char* __file, unsigned int __line, const char* __function);
[[noreturn]] extern void __assert(const char* __assertion, const char* __file, int __line);
typedef long int __off_t;
typedef long int __off64_t;
typedef __off64_t __loff_t;
typedef int __sig_atomic_t;
struct _IO_FILE;
typedef struct _IO_FILE __FILE;
struct _IO_marker;
struct _IO_codecvt;
struct _IO_wide_data;
typedef void _IO_lock_t;
typedef struct _IO_FILE FILE;
int main();

struct _IO_FILE {
	int _flags;
	char* _IO_read_ptr;
	char* _IO_read_end;
	char* _IO_read_base;
	char* _IO_write_base;
	char* _IO_write_ptr;
	char* _IO_write_end;
	char* _IO_buf_base;
	char* _IO_buf_end;
	char* _IO_save_base;
	char* _IO_backup_base;
	char* _IO_save_end;
	struct _IO_marker* _markers;
	struct _IO_FILE* _chain;
	int _fileno;
	int _flags2;
	__off_t _old_offset;
	unsigned short int _cur_column;
	signed char _vtable_offset;
	char _shortbuf[1];
	_IO_lock_t* _lock;
	__off64_t _offset;
	struct _IO_codecvt* _codecvt;
	struct _IO_wide_data* _wide_data;
	struct _IO_FILE* _freeres_list;
	void* _freeres_buf;
	struct _IO_FILE** _prevchain;
	int _mode;
	char _unused2[80];
};
FILE* stderr;
int main() {
	(0 && "error") ? ((void)0) : __assert_fail("0 && \"error\"", "/a/b/c", 49, __func__);
}
```