### PR TITLE
Make the warning preprocessor valid in all standards

### DIFF
--- a/src/core/cc/ci/scanner.c
+++ b/src/core/cc/ci/scanner.c
@@ -770,7 +770,10 @@ static const CIFeature tokens_feature[CI_TOKEN_KIND_MAX] = {
                                             .until = CI_STANDARD_NONE },
     [CI_TOKEN_KIND_PREPROCESSOR_UNDEF] = { .since = CI_STANDARD_NONE,
                                            .until = CI_STANDARD_NONE },
-    [CI_TOKEN_KIND_PREPROCESSOR_WARNING] = { .since = CI_STANDARD_23,
+    // NOTE: Normally, the preprocessor `#warning` is only supported in C23, but
+    // it seems that Clang and GCC use it as an extension so that this feature
+    // is valid in all standards.
+    [CI_TOKEN_KIND_PREPROCESSOR_WARNING] = { .since = CI_STANDARD_NONE,
                                              .until = CI_STANDARD_NONE },
     [CI_TOKEN_KIND_RBRACE] = { .since = CI_STANDARD_NONE,
                                .until = CI_STANDARD_NONE },


### PR DESCRIPTION
You can probably see an example of the `#warning` preprocessor in all standards in the include `/usr/include/features.h`:

```c
// ...
#if (defined _BSD_SOURCE || defined _SVID_SOURCE) \
    && !defined _DEFAULT_SOURCE
# warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
# undef  _DEFAULT_SOURCE
# define _DEFAULT_SOURCE    1
#endif
// ...
```