### PR TITLE
Fix bug in generation of for init clause semicolon

### DIFF
--- a/src/core/cc/ci/generator.c
+++ b/src/core/cc/ci/generator.c
@@ -1378,9 +1378,9 @@ generate_function_for_stmt__CIGenerator(const CIStmtFor *for_)
 
     if (for_->init_clause) {
         generate_function_body_item__CIGenerator(for_->init_clause);
+    } else {
+        write_str__CIGenerator(";");
     }
-
-    write_str__CIGenerator(";");
 
     if (for_->expr1) {
         generate_function_expr__CIGenerator(for_->expr1);


### PR DESCRIPTION
bug example:

```c
int main() {
 for (int i = 0; i < 10; ++i) {
 }
}
```

generate:

```c
int main() {
   for (int i = 0;
;i < 10;i++) {
   }
}
```