### PR TITLE
Fix bug on substitution of fields and get data type of enum variant

### DIFF
--- a/include/core/cc/ci/ast.h
+++ b/include/core/cc/ci/ast.h
@@ -1939,7 +1939,9 @@ IMPL_FOR_DEBUG(to_string, CIDeclKind, enum CIDeclKind self);
 
 typedef struct CIDeclEnumVariant
 {
-    Rc *name; // Rc<String*>*
+    Rc *enum_name;              // Rc<String*>*?
+    CIDataType *enum_data_type; // CIDataType*?
+    Rc *name;                   // Rc<String*>*
     Isize value;
     Usize ref_count;
 } CIDeclEnumVariant;
@@ -1947,9 +1949,16 @@ typedef struct CIDeclEnumVariant
 /**
  *
  * @brief Construct CIDeclEnumVariant type.
+ * @param enum_name Rc<String*>*? (&)
+ * @param enum_data_type CIDataType*? (&)
  * @param name Rc<String*>* (&)
  */
-CONSTRUCTOR(CIDeclEnumVariant *, CIDeclEnumVariant, Rc *name, Isize value);
+CONSTRUCTOR(CIDeclEnumVariant *,
+            CIDeclEnumVariant,
+            Rc *enum_name,
+            CIDataType *enum_data_type,
+            Rc *name,
+            Isize value);
 
 /**
  *

--- a/src/core/cc/ci/infer.c
+++ b/src/core/cc/ci/infer.c
@@ -461,8 +461,21 @@ infer_expr_identifier_data_type__CIInfer(
 
             break;
         }
-        case CI_EXPR_IDENTIFIER_ID_KIND_ENUM_VARIANT:
-            TODO("enum variant");
+        case CI_EXPR_IDENTIFIER_ID_KIND_ENUM_VARIANT: {
+            CIDecl *enum_variant_decl = get_enum_variant_from_id__CIResultFile(
+              file, expr->identifier.id.enum_variant);
+
+            ASSERT(enum_variant_decl);
+
+            CIDataType *enum_data_type =
+              enum_variant_decl->enum_variant->enum_data_type;
+
+            if (enum_data_type) {
+                return ref__CIDataType(enum_data_type);
+            }
+
+            return NEW(CIDataType, CI_DATA_TYPE_KIND_INT);
+        }
         case CI_EXPR_IDENTIFIER_ID_KIND_FUNCTION: {
             // TODO: Call generic function is not yet implemented
             CIDecl *decl = get_function_from_id__CIResultFile(
@@ -605,7 +618,16 @@ infer_expr_unary_data_type__CIInfer(
                                                      unary_right_expr_data_type,
                                                      called_generic_params,
                                                      decl_generic_params)) {
-                TODO("get the type after dereferencing");
+                CIDataType *res = ref__CIDataType(
+                  unwrap_implicit_ptr_data_type__CIResolverDataType(
+                    file,
+                    unary_right_expr_data_type,
+                    called_generic_params,
+                    decl_generic_params));
+
+                FREE(CIDataType, unary_right_expr_data_type);
+
+                return res;
             }
 
             return unary_right_expr_data_type;

--- a/src/core/cc/ci/parser.c
+++ b/src/core/cc/ci/parser.c
@@ -219,9 +219,12 @@ static CIDataType *
 parse_pre_data_type__CIParser(CIParser *self);
 
 /// @brief Parse enum variants.
+/// @param enum_name Rc<String*>* (&)
 /// @return Vec<CIDeclEnumVariant*>*
 static Vec *
-parse_enum_variants__CIParser(CIParser *self);
+parse_enum_variants__CIParser(CIParser *self,
+                              Rc *enum_name,
+                              CIDataType *enum_data_type);
 
 /// @brief Parse enum declaration.
 /// @param name Rc<String*>* (&)
@@ -2146,7 +2149,9 @@ parse_data_type__CIParser(CIParser *self)
 }
 
 Vec *
-parse_enum_variants__CIParser(CIParser *self)
+parse_enum_variants__CIParser(CIParser *self,
+                              Rc *enum_name,
+                              CIDataType *enum_data_type)
 {
     Vec *variants = NEW(Vec); // Vec<CIDeclEnumVariant*>*
     Isize precedent_value = -1;
@@ -2187,7 +2192,11 @@ parse_enum_variants__CIParser(CIParser *self)
                 }
 
                 precedent_value = custom_value;
-                variant = NEW(CIDeclEnumVariant, name, custom_value);
+                variant = NEW(CIDeclEnumVariant,
+                              enum_name,
+                              enum_data_type,
+                              name,
+                              custom_value);
 
                 push__Vec(variants, variant);
 
@@ -2197,7 +2206,11 @@ parse_enum_variants__CIParser(CIParser *self)
                 break;
             }
             default:
-                variant = NEW(CIDeclEnumVariant, name, ++precedent_value);
+                variant = NEW(CIDeclEnumVariant,
+                              enum_name,
+                              enum_data_type,
+                              name,
+                              ++precedent_value);
 
                 push__Vec(variants, variant);
         }
@@ -2260,12 +2273,14 @@ parse_enum__CIParser(CIParser *self, int storage_class_flag, Rc *name)
             FAILED("expected `{` or `;`");
     }
 
-    return NEW_VARIANT(
-      CIDecl,
-      enum,
-      storage_class_flag,
-      false,
-      NEW(CIDeclEnum, name, parse_enum_variants__CIParser(self), data_type));
+    return NEW_VARIANT(CIDecl,
+                       enum,
+                       storage_class_flag,
+                       false,
+                       NEW(CIDeclEnum,
+                           name,
+                           parse_enum_variants__CIParser(self, name, data_type),
+                           data_type));
 }
 
 Vec *


### PR DESCRIPTION
Fix bugs from this example:

```c
#include <stdio.h>
#include <errno.h>
#include <stdlib.h>
#include <string.h>
#include <sys/stat.h>

enum ResultKind {
	RESULT_KIND_OK,
	RESULT_KIND_ERR
};

typedef struct Result.[@T, @E] {
	enum ResultKind kind;
	union {
		@T ok;
		@E err;
	};
} Result.[@T, @E];

enum ReadFileErrorKind {
	READ_FILE_ERROR_KIND_FALED_TO_OPEN_FILE,
	READ_FILE_ERROR_KIND_OUT_OF_MEMORY,
	READ_FILE_ERROR_KIND_FAILED_TO_CLOSE_FILE,
	READ_FILE_ERROR_KIND_FAILED_TO_READ
};

typedef struct ReadFileError {
	enum ReadFileErrorKind kind;
	union {
		int failed_to_open_file;
	};
} ReadFileError;

Result.[char*, ReadFileError]
read_file(const char *path) {
	FILE *file = fopen(path, "r");

	if (!file) {
		return (Result.[char*, ReadFileError]){
			.kind = RESULT_KIND_ERR,
			.err = (ReadFileError){
				.kind = READ_FILE_ERROR_KIND_FALED_TO_OPEN_FILE,
				.failed_to_open_file = errno
			}
		};
	}

	struct stat st;

	stat(path, &st);

	size_t n = st.st_size + 1;
	char *buffer = malloc(n);

	if (!buffer) {
		return (Result.[char*, ReadFileError]){
			.kind = RESULT_KIND_ERR,
			.err = (ReadFileError){
				.kind = READ_FILE_ERROR_KIND_OUT_OF_MEMORY
			}
		};
	}

	memset(buffer, 0, n);

	if (fread(buffer, sizeof(char), n, file) != n - 1) {
		return (Result.[char*, ReadFileError]){
			.kind = RESULT_KIND_ERR,
			.err = (ReadFileError){
				.kind = READ_FILE_ERROR_KIND_FAILED_TO_READ
			}
		};
	}

	if (fclose(file) != 0) {
		return (Result.[char*, ReadFileError]){
			.kind = RESULT_KIND_ERR,
			.err = (ReadFileError){
				.kind = READ_FILE_ERROR_KIND_FAILED_TO_CLOSE_FILE
			}
		};
	}

	return (Result.[char*, ReadFileError]){
		.kind = RESULT_KIND_OK,
		.ok = buffer
	};
}

int main() {
	Result.[char*, ReadFileError] read_result = read_file("README.md");

	switch (read_result.kind) {
		case RESULT_KIND_OK:
			printf("OK:\n%s\n", read_result.ok);
			free(read_result.ok);
			break;
		case RESULT_KIND_ERR:
			printf("ERR\n");
			break;
		default:
			break;
	}
}
```