### PR TITLE
Fix bad error "data type is not expected with initializer"

### DIFF
--- a/src/core/cc/ci/ast.c
+++ b/src/core/cc/ci/ast.c
@@ -1510,9 +1510,11 @@ get_next_member__CIDeclStructField(const CIDeclStructField *self)
 CIDeclStructField *
 skip_fields_with_given_parent__CIDeclStructField(CIDeclStructField *self)
 {
+    CIDeclStructField *initial_field = self;
     CIDeclStructField *current = self->next;
 
-    while (current && has_parent_by_addr__CIDeclStructField(current, self)) {
+    while (current && has_parent_by_addr__CIDeclStructField(
+                        current, initial_field->parent)) {
         current = current->next;
     }
 


### PR DESCRIPTION
e.g.

```c
struct A {
	int a, b;
};

struct X {
	int a, b;
	union {
		int x;
		int y;
	};
	struct A z;
};

int main() {
	struct X x = { 10, 30, 30, {20, 30} };
	struct X x2 = { .a = 10, .b = 30, .x = 30, .z = { 10, 10 } };
	struct X x3 = { 0, 1 };
	struct A a = { 1, 2 };
}
```